### PR TITLE
Roster uses name attribute if available

### DIFF
--- a/lib/xmpp-client/client.js
+++ b/lib/xmpp-client/client.js
@@ -54,7 +54,7 @@ Client.prototype.getRoster = function(callback) {
 	this.iq(null, new xmpp.Element('query', {xmlns: 'jabber:iq:roster'}), function(iq) {
 		iq.getChild('query', 'jabber:iq:roster').getChildren('item').forEach(function(child) {
 			jabber.roster[child.attrs.jid] = {
-				name: child.attrs.jid,
+				name: child.attrs.name || child.attrs.jid,
 				subscription: child.attrs.subscription};
 		});
 		jabber.emit('roster', jabber.roster);


### PR DESCRIPTION
Roster was returning JID for the name in the roster object.  XMPP supports optional custom names to be sent with the roster.  This patch uses that name if available and falls back on the JID if no name is provided.
